### PR TITLE
Change arg checking to explicit check for None

### DIFF
--- a/hypergraph/core.py
+++ b/hypergraph/core.py
@@ -26,7 +26,7 @@ class Edge(frozenset):
             assert all([vertex.__hash__ for vertex in edge])
         except (AttributeError, AssertionError):
             raise TypeError('vertices must be immutable')
-        if not edge:
+        if len(edge) < 1:
             raise ValueError('edge must contain at least one vertex')
         return frozenset.__new__(cls, edge)
 
@@ -41,7 +41,7 @@ class Edge(frozenset):
         @raise ValueError: Specified head vertex not in edge.
         """
         try:
-            assert not head or head in self
+            assert head is None or head in self
         except AssertionError:
             raise ValueError('edge has no vertex %s' % head)
         self._head = head
@@ -51,7 +51,7 @@ class Edge(frozenset):
         Hash function.
         """
         return super(Edge, self).__hash__() + \
-            (self.head.__hash__() if self.head else 0)
+            (self.head.__hash__() if self.head is not None else 0)
 
     def __eq__(self, other):
         """\
@@ -119,8 +119,8 @@ class Hypergraph(object):
         try:
             for edge in edges:
                 assert isinstance(edge, Edge)
-                assert (not directed and not edge.head) \
-                    or (directed and edge.head)
+                assert (not directed and edge.head is None) \
+                    or (directed and edge.head is not None)
                 try:
                     self.weights[edge] = float(weights[edge])
                 except (KeyError, TypeError):
@@ -191,8 +191,8 @@ class Hypergraph(object):
         """
         try:
             assert isinstance(edge, Edge)
-            assert (not self.directed and not edge.head) \
-                or (self.directed and edge.head)
+            assert (not self.directed and edge.head is None) \
+                or (self.directed and edge.head is not None)
         except AssertionError:
             raise ValueError('invalid edge %s' % edge)
         self._vertices.update(edge)

--- a/hypergraph/core.py
+++ b/hypergraph/core.py
@@ -107,8 +107,8 @@ class Hypergraph(object):
         @raise TypeError: One or more vertices are not immutable.
         @raise ValueError: One or more edges are not valid for this hypergraph.
         """
-        vertices = set(vertices) if vertices else set()
-        edges = set(edges) if edges else set()
+        vertices = set(vertices) if vertices is not None else set()
+        edges = set(edges) if edges is not None else set()
         self._directed = directed
         try:
             assert all([vertex.__hash__ for vertex in vertices])

--- a/test.py
+++ b/test.py
@@ -66,6 +66,14 @@ class TestCore(unittest.TestCase):
         self.D.add_edge(Edge(['A', 'C', 'B', 'E', 'D', 'G', 'F', 'I', 'H'], 'E'), weight=6.847455)
         self.D.add_edge(Edge(['A', 'C', 'B', 'E', 'D', 'F', 'H', 'J'], 'D'), weight=9.601762)
 
+    def test_zero_head(self):
+        G = Hypergraph(vertices=[0, 1, 2, 3], directed=True)
+        self.assertTrue(0 in G.vertices)
+        E = Edge([0], head=0)
+        self.assertTrue(E.head == 0)
+        G.add_edge(E)
+        self.assertTrue(E in G.edges)
+
     def test_equal_repr(self):
         self.assertEqual(Hypergraph(), Hypergraph())
         self.assertEqual(Graph(), Graph())


### PR DESCRIPTION
When checking for None, it's better to explicitly test

    x = val if val is not None else default

instead of

    x = val if val else default

If the val cannot be implicitly converted to a bool (but is otherwise
valid) the second test will throw an exeption.

As an example of code that this commit fixes, consider the following:

    G = Graph(np.arange(10))

Before this commit, this would fail with the error 

> ValueError: The truth value of an array with more than one element is ambiguous.

After this commit, it succeeds as we would expect.